### PR TITLE
Updates to the proxy-rewrite.regex_uri's URL template for Service Routes routes

### DIFF
--- a/utils.js
+++ b/utils.js
@@ -71,7 +71,7 @@ let util = {
             "uri": "/apis/sr*",
             "plugins": {
                 "proxy-rewrite": {
-                    "regex_uri": ["^/apis/sr(.*)", (SR_URL_CONTEXT_PATH === "" ? "" : "/" + SR_URL_CONTEXT_PATH)  + "/$1"],
+                    "regex_uri": ["^/apis/sr(.*)", (SR_URL_CONTEXT_PATH === "" ? "" : "/" + SR_URL_CONTEXT_PATH)  + "$1"],
                     "scheme": url.protocol === "http:" ? "http" : "https"
                 },
                 "authz-keycloak": {
@@ -95,7 +95,7 @@ let util = {
             "uri": "/apis/sr*",
             "plugins": {
                 "proxy-rewrite": {
-                    "regex_uri": ["^/apis/sr(.*)", (SR_URL_CONTEXT_PATH === "" ? "" : "/" + SR_URL_CONTEXT_PATH)  + "/$1"],
+                    "regex_uri": ["^/apis/sr(.*)", (SR_URL_CONTEXT_PATH === "" ? "" : "/" + SR_URL_CONTEXT_PATH)  + "$1"],
                     "scheme": url.protocol === "http:" ? "http" : "https"
                 },
                 "authz-keycloak": {


### PR DESCRIPTION
#### Issue with proxy-rewrite in TEST env

The TEST env Service Registry (SR) is now accessible at `https://test-env.example.org/apis/sr` and GET/POST on this URL work. However, GET/PUT/DELETE on `https://test-env.example.org/apis/sr/<id1>` return http 405 - Method not allowed. This is because of the proxy-rewrite plugin's configuration/behavior. 

Current proxy-rewrite config for **TEST env SR routes** (routes 2 & 3) in apisix:
```
"proxy-rewrite": {
                    "regex_uri": [
                        "^/apis/sr(.*)",
                        "/$1"
                    ],
                    "scheme": "http"
                }
```
```
https://test-env.example.org/apis/sr --> http://localhost:8082/ --> valid
https://test-env.example.org/apis/sr/ --> http://localhost:8082// --> valid
https://test-env.example.org/apis/sr/id1 --> http://localhost:8082//id --> invalid (results in http 405 error)
```

This, however, works in the DEV env.

Current proxy-rewrite config for **DEV env SR routes**  (routes 2 & 3) in apisix:
```
"proxy-rewrite": {
                    "regex_uri": [
                        "^/apis/sr(.*)",
                        "/services/$1"
                    ],
                    "scheme": "https"
                }
```
```
https://efs.dev-env.example.com/apis/sr --> https://dev-env.example.org/services/ --> valid
https://efs.dev-env.example.com/apis/sr/ --> https://dev-env.example.org/services// --> valid
https://efs.dev-env.example.com/apis/sr/id1 --> https://dev-env.example.org/services//id --> valid
```

#### Workaround to be applied
- In the proxy-rewrite.regex_uri's URL template, use `$1` instead of `/$1` (this is to be done in asg-importer's code ([here](https://github.com/nimble-platform/asg-importer/blob/fdeb257c1de7afc1f44e84aa24eacdd183312c48/utils.js#L74) and [here](https://github.com/nimble-platform/asg-importer/blob/fdeb257c1de7afc1f44e84aa24eacdd183312c48/utils.js#L98)), which creates the routes (2 and 3) for SR in apisix)
- With this, the calls to DEV as well as TEST env SRs will work, with one **side-effect**: the calls to `/apis/sr` in both envs will fail (all other calls will succeed) -- this is a bit strange, the regex still matches correctly for `/apis/sr` and the URL template is returned as empty by the proxy-rewrite plugin in the TEST env. However, apisix does not perform the substitution as expected... the original URL from the client (i.e. `/apis/sr`) is substituted instead (`https://test-env.example.org/apis/sr` --> `http://localhost:8082/apis/sr`) resulting in an error on the SR's side (404 - service with id `apis/sr` not found).
- On the positive side, the calls to SR's root URL with `/apis/sr/` will continue to work as expected (including all the other calls `/apis/sr/<id1>`)

<details>
<summary>Details</summary>
<p>

Workaound: NEW proxy-rewrite config for **TEST env SR routes** (routes 2 & 3) in apisix:
```
"proxy-rewrite": {
                    "regex_uri": [
                        "^/apis/sr(.*)",
                        "$1"
                    ],
                    "scheme": "http"
                }
```
```
https://test-env.example.org/apis/sr --> http://localhost:8082/apis/sr --> not as expected/invalid
https://test-env.example.org/apis/sr/ --> http://localhost:8082/ --> valid
https://test-env.example.org/apis/sr/id1 --> http://localhost:8082/id --> valid
```

Workaround: NEW proxy-rewrite config for **DEV env SR routes**  (routes 2 & 3) in apisix:
```
"proxy-rewrite": {
                    "regex_uri": [
                        "^/apis/sr(.*)",
                        "/services$1"
                    ],
                    "scheme": "https"
                }
```
```
https://efs.dev-env.example.com/apis/sr --> https://dev-env.example.org/services/apis/sr --> not as expected/invalid (the error is indeed http 404 from apisix)
https://efs.dev-env.example.com/apis/sr/ --> https://dev-env.example.org/services/ --> valid
https://efs.dev-env.example.com/apis/sr/id1 --> https://dev-env.example.org/services/id --> valid
```

</p>
</details>


#### References
1. https://github.com/apache/apisix/blob/master/docs/en/latest/plugins/proxy-rewrite.md
2. https://github.com/apache/apisix/blob/2b532f06ba8a48da0b8c21147bee7d2cb0391a2e/apisix/plugins/proxy-rewrite.lua#L150
3. https://github.com/openresty/lua-nginx-module#ngxresub
4. https://regex101.com/