### PR TITLE
Enable authorization capability for secure proxy routes in APISIX based on a flag in Service Registration objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 ### Configuration: Environment variables (ENVs)
 - SR_URL: Base URL of the Service Registry (SR). The URL that returns SR's index page which contains all the registered services. E.g., `http://www.example.com/services`.
 - EFS_KEYCLOAK_URL: Base URL of the EFS Keycloak. E.g., If the EFS Keycloak's OpenId Connect discovery URL is `http://www.example.com/auth/realms/master/.well-known/openid-configuration`, the EFS_KEYCLOAK_URL would be `http://www.example.com`.
+- EFS_KEYCLOAK_REALM: Name of the realm from EFS Keycloak
 - ASG_URL: Base URL of the API Security Gateway (ASG). E.g., If the ASG returns its routes on calling `http://www.example.com/apisix/admin/routes`, the ASG_URL would be `http://www.example.com`.
 - X_API_KEY: x-api-key for accessing ASG's API
 - CLIENT_ID: CLIENT_ID for the APISIX client in the EFS Keycloak

--- a/app.js
+++ b/app.js
@@ -4,6 +4,7 @@ const utils = require("./utils");
 
 let SR_URL = process.env.SR_URL;        // Base URL of the Service Registry (LinkSmart Service Catalog)
 let EFS_KEYCLOAK_URL = process.env.EFS_KEYCLOAK_URL;        // Base URL of the EFS Keycloak
+let EFS_KEYCLOAK_REALM = process.env.EFS_KEYCLOAK_REALM;        // Name of the realm
 let ASG_URL = process.env.ASG_URL;      // Base URL of the API Security Gateway (Apache APISIX)
 let X_API_KEY = process.env.X_API_KEY;      // x-api-key for accessing APISIX's API
 let CLIENT_ID = process.env.CLIENT_ID;
@@ -49,7 +50,7 @@ const syncData = async SR_URL => {
         const asgJSON = await asgResponse.json();
 
         utils.createOrUpdateEcoEndpoint(asgJSON, ASG_URL, X_API_KEY);
-        utils.createServiceRegistryEndpoint(SR_URL, EFS_KEYCLOAK_URL, ASG_URL, X_API_KEY, SR_URL_CONTEXT_PATH);
+        utils.createServiceRegistryEndpoint(SR_URL, EFS_KEYCLOAK_URL, EFS_KEYCLOAK_REALM, ASG_URL, X_API_KEY, SR_URL_CONTEXT_PATH);
         fillAvailableRoutes(asgJSON);
         // iterate through all the requests
         let services = srJSON.services;
@@ -134,7 +135,7 @@ const syncData = async SR_URL => {
                                                 "regex_uri": [regex, regexReplace]
                                             },
                                             "authz-keycloak": {
-                                                "token_endpoint": `${EFS_KEYCLOAK_URL}/auth/realms/master/protocol/openid-connect/token`,
+                                                "token_endpoint": `${EFS_KEYCLOAK_URL}/auth/realms/${EFS_KEYCLOAK_REALM}/protocol/openid-connect/token`,
                                                 "permissions": [rootService.id + "#" + rootService.apis[j].id + "_view"],    // "<resource_name>#<scope_name>"
                                                 "audience": "apisix",
                                                 "ssl_verify": false
@@ -156,7 +157,7 @@ const syncData = async SR_URL => {
                                                 "regex_uri": [regex, regexReplace]
                                             },
                                             "authz-keycloak": {
-                                                "token_endpoint": `${EFS_KEYCLOAK_URL}/auth/realms/master/protocol/openid-connect/token`,
+                                                "token_endpoint": `${EFS_KEYCLOAK_URL}/auth/realms/${EFS_KEYCLOAK_REALM}/protocol/openid-connect/token`,
                                                 "permissions": [rootService.id + "#" + rootService.apis[j].id + "_admin"],    // "<resource_name>#<scope_name>"
                                                 "audience": "apisix",
                                                 "ssl_verify": false
@@ -178,10 +179,10 @@ const syncData = async SR_URL => {
                                                 "regex_uri": [regex, regexReplace]
                                             },
                                             "openid-connect": {
-                                                "discovery": `${EFS_KEYCLOAK_URL}/auth/realms/master/.well-known/openid-configuration`,
+                                                "discovery": `${EFS_KEYCLOAK_URL}/auth/realms/${EFS_KEYCLOAK_REALM}/.well-known/openid-configuration`,
                                                 "bearer_only": true,
                                                 "realm": "master",
-                                                // "introspection_endpoint": `${EFS_KEYCLOAK_URL}/auth/realms/master/protocol/openid-connect/token/introspect`
+                                                // "introspection_endpoint": `${EFS_KEYCLOAK_URL}/auth/realms/${EFS_KEYCLOAK_REALM}/protocol/openid-connect/token/introspect`
                                                 "token_signing_alg_values_expected": "RS256",
                                                 "client_id":"testClient",
                                                 "client_secret":"testSecret",

--- a/app.js
+++ b/app.js
@@ -181,7 +181,7 @@ const syncData = async SR_URL => {
                                             "openid-connect": {
                                                 "discovery": `${EFS_KEYCLOAK_URL}/auth/realms/${EFS_KEYCLOAK_REALM}/.well-known/openid-configuration`,
                                                 "bearer_only": true,
-                                                "realm": "master",
+                                                "realm": `${EFS_KEYCLOAK_REALM}`,
                                                 // "introspection_endpoint": `${EFS_KEYCLOAK_URL}/auth/realms/${EFS_KEYCLOAK_REALM}/protocol/openid-connect/token/introspect`
                                                 "token_signing_alg_values_expected": "RS256",
                                                 "client_id":"testClient",

--- a/utils.js
+++ b/utils.js
@@ -46,7 +46,7 @@ let util = {
         return routeID;
     }),
 
-    createServiceRegistryEndpoint: ((SR_URL, EFS_KEYCLOAK_URL, ASG_URL, X_API_KEY, SR_URL_CONTEXT_PATH) => {
+    createServiceRegistryEndpoint: ((SR_URL, EFS_KEYCLOAK_URL, EFS_KEYCLOAK_REALM, ASG_URL, X_API_KEY, SR_URL_CONTEXT_PATH) => {
 
         let url_split = SR_URL;
         if(SR_URL_CONTEXT_PATH !== "") {
@@ -75,7 +75,7 @@ let util = {
                     "scheme": url.protocol === "http:" ? "http" : "https"
                 },
                 "authz-keycloak": {
-                    "token_endpoint": `${EFS_KEYCLOAK_URL}/auth/realms/master/protocol/openid-connect/token`,
+                    "token_endpoint": `${EFS_KEYCLOAK_URL}/auth/realms/${EFS_KEYCLOAK_REALM}/protocol/openid-connect/token`,
                     "permissions": ["service_registry#sr_view"],
                     "audience": "apisix",
                     "ssl_verify": false
@@ -99,7 +99,7 @@ let util = {
                     "scheme": url.protocol === "http:" ? "http" : "https"
                 },
                 "authz-keycloak": {
-                    "token_endpoint": `${EFS_KEYCLOAK_URL}/auth/realms/master/protocol/openid-connect/token`,
+                    "token_endpoint": `${EFS_KEYCLOAK_URL}/auth/realms/${EFS_KEYCLOAK_REALM}/protocol/openid-connect/token`,
                     "permissions": ["service_registry#sr_admin"],
                     "audience": "apisix",
                     "ssl_verify": false

--- a/utils.js
+++ b/utils.js
@@ -91,7 +91,7 @@ let util = {
 
 
         const srAdminBody = {
-            "methods": ["POST", "PUT", "PATCH", "DELETE", "OPTIONS"],
+            "methods": ["POST", "PUT", "PATCH", "DELETE", "GET", "OPTIONS"],
             "uri": "/apis/sr*",
             "plugins": {
                 "proxy-rewrite": {

--- a/utils.js
+++ b/utils.js
@@ -91,7 +91,7 @@ let util = {
 
 
         const srAdminBody = {
-            "methods": ["POST", "PUT", "PATCH", "DELETE", "GET", "OPTIONS"],
+            "methods": ["POST", "PUT", "PATCH", "DELETE", "OPTIONS"],
             "uri": "/apis/sr*",
             "plugins": {
                 "proxy-rewrite": {


### PR DESCRIPTION
Updates:
1. Enable authorization if the meta.dataspine.enableAuthZ flag is set in a Service Registration object:
    - If meta.dataspine.enableAuthZ is true, use the authz-keycloak plugin to enforce authorization, else use the openid-connect for authentication (no authorization)
    - If meta.dataspine.enableAuthZ is true, this enables support for two authorization/access-levels: (1) either a user has full, admin-level access (CRUD) to the API or (2) no access at all
2. Moved realm name to ENV